### PR TITLE
Do not restart rabbitmq unless new plugins were enabled

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,6 +35,7 @@
   rabbitmq_plugin: >
     names=rabbitmq_management,rabbitmq_tracing,rabbitmq_federation
     state=enabled
+  register: enable_rabbitmq_plugins_result
 
   # MUST RESTART SERVER AFTER ENABLING PLUGINS
 - name: 'Restart rabbitmq'
@@ -43,6 +44,7 @@
   service: >
     name=rabbitmq-server
     state=restarted
+  when: enable_rabbitmq_plugins_result.changed
   
 - name: 'Add administrators'
   tags: 'rabbitmq'


### PR DESCRIPTION
Currently this role restarts rabbitmq every time it's run. This change avoids restarting rabbitmq if it is not needed (e.g. you're rerunning the playbook on an existing server).